### PR TITLE
Citation Summary Page + More

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["unsubscriber"]
+}

--- a/auth_config.json
+++ b/auth_config.json
@@ -1,4 +1,5 @@
 {
   "domain": "dev-3k36-3cg.us.auth0.com",
-  "clientId": "AUMp2619jwCfVNLdeW6uRSTJUt3wQk01"
+  "clientId": "AUMp2619jwCfVNLdeW6uRSTJUt3wQk01",
+  "apiUrl": "https://traffic-citation-backend.herokuapp.com/api"
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,7 +20,7 @@ const routes: Routes = [
   { path: 'app', component: AppComponent },
   { path: 'home', component: HomeComponent, title: 'Traffic Citation Interface' },
   { path: 'profile', component: ProfileComponent, title: 'Profile'},
-  { path: 'create-citation/:id', component: CreateCitationComponent, title: 'Add Citation' },
+  { path: 'create-citation', component: CreateCitationComponent, title: 'Add Citation' },
   { path: 'view-citation-summary', component: ViewCitationSummaryComponent, title: 'Viewing Citation Summary' },
   { path: 'edit-citation', component: EditCitationComponent, title: 'Editing Citations' },
   { path: 'view-citations', component: ViewCitationsComponent, title: 'Viewing Citations' },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,11 +12,13 @@ import { LoginComponent } from './components/login/login.component';
 import { CreateDriverComponent } from './components/driver/create-driver/create-driver.component';
 import { EditDriverComponent } from './components/driver/edit-driver/edit-driver.component';
 import { DriverLicenseDialogComponent } from './components/driver/driver-license-dialog/driver-license-dialog.component';
+import { ProfileComponent } from './components/profile/profile.component';
 
 // Define all routes in Routes array
 const routes: Routes = [
   { path: 'app', component: AppComponent },
   { path: 'home', component: HomeComponent, title: 'Traffic Citation Interface' },
+  { path: 'profile', component: ProfileComponent, title: 'Profile'},
   { path: 'create-citation/:id', component: CreateCitationComponent, title: 'Add Citation' },
   { path: 'edit-citation', component: EditCitationComponent, title: 'Editing Citations' },
   { path: 'view-citations', component: ViewCitationsComponent, title: 'Viewing Citations' },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { CreateDriverComponent } from './components/driver/create-driver/create-
 import { EditDriverComponent } from './components/driver/edit-driver/edit-driver.component';
 import { DriverLicenseDialogComponent } from './components/driver/driver-license-dialog/driver-license-dialog.component';
 import { ProfileComponent } from './components/profile/profile.component';
+import { ViewCitationSummaryComponent } from './components/citations/view-citation-summary/view-citation-summary.component';
 
 // Define all routes in Routes array
 const routes: Routes = [
@@ -20,6 +21,7 @@ const routes: Routes = [
   { path: 'home', component: HomeComponent, title: 'Traffic Citation Interface' },
   { path: 'profile', component: ProfileComponent, title: 'Profile'},
   { path: 'create-citation/:id', component: CreateCitationComponent, title: 'Add Citation' },
+  { path: 'view-citation-summary/:id', component: ViewCitationSummaryComponent, title: 'Viewing Citation Summary' },
   { path: 'edit-citation', component: EditCitationComponent, title: 'Editing Citations' },
   { path: 'view-citations', component: ViewCitationsComponent, title: 'Viewing Citations' },
   { path: 'driver-dialog', component: DriverLicenseDialogComponent, title: 'Check for driver' },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,7 +21,7 @@ const routes: Routes = [
   { path: 'home', component: HomeComponent, title: 'Traffic Citation Interface' },
   { path: 'profile', component: ProfileComponent, title: 'Profile'},
   { path: 'create-citation/:id', component: CreateCitationComponent, title: 'Add Citation' },
-  { path: 'view-citation-summary/:id', component: ViewCitationSummaryComponent, title: 'Viewing Citation Summary' },
+  { path: 'view-citation-summary', component: ViewCitationSummaryComponent, title: 'Viewing Citation Summary' },
   { path: 'edit-citation', component: EditCitationComponent, title: 'Editing Citations' },
   { path: 'view-citations', component: ViewCitationsComponent, title: 'Viewing Citations' },
   { path: 'driver-dialog', component: DriverLicenseDialogComponent, title: 'Check for driver' },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
             <a routerLink="/home" routerLinkActive="active" ariaCurrentWhenActive="page">Home</a>
         </li>
         <li>
-            <a routerLink="/create-driver" routerLinkActive="active" ariaCurrentWhenActive="page">Create Citation</a>
+            <a routerLink="/create-citation" routerLinkActive="active" ariaCurrentWhenActive="page">Create Citation</a>
         </li>
         <li>
             <a routerLink="/view-citations" routerLinkActive="active" ariaCurrentWhenActive="page">View Citations</a>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
-import { MatCardModule } from '@angular/material/card' 
+import { MatCardModule } from '@angular/material/card'
+import { MatTabsModule } from '@angular/material/tabs';
+
 
 //Auth0
 import { AuthModule } from '@auth0/auth0-angular';
@@ -43,6 +45,7 @@ import { FormatTimeSpan } from './components/citations/view-citations/formatTime
 import { DriverLicenseDialogComponent } from './components/driver/driver-license-dialog/driver-license-dialog.component';
 import { InputErrorStateMatcher } from './error-state-matching';
 import { ProfileComponent } from './components/profile/profile.component';
+import { ViewCitationSummaryComponent } from './components/citations/view-citation-summary/view-citation-summary.component';
 
 @NgModule({
   declarations: [
@@ -58,6 +61,7 @@ import { ProfileComponent } from './components/profile/profile.component';
     FormatTimeSpan,
     DriverLicenseDialogComponent,
     ProfileComponent,
+    ViewCitationSummaryComponent,
   ],
   imports: [
     AuthModule.forRoot({
@@ -84,7 +88,8 @@ import { ProfileComponent } from './components/profile/profile.component';
     MatSnackBarModule,
     MatButtonModule,
     MatIconModule,
-    MatCardModule
+    MatCardModule,
+    MatTabsModule
   ],
   providers: [
     {provide: MatDialogRef, useValue: {}}, CitationService, 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,15 +15,16 @@ import { MatTableModule } from '@angular/material/table';
 import { MatSortModule } from '@angular/material/sort';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA, MAT_DIALOG_DEFAULT_OPTIONS} from '@angular/material/dialog'
-import { AuthModule } from '@auth0/auth0-angular';
-import { environment as env } from '../environments/environment';
-import { auth0 as auth0} from '../environments/auth0.prod';
 import { AppRoutingModule } from './app-routing.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
 import { MatCardModule } from '@angular/material/card' 
+
+//Auth0
+import { AuthModule } from '@auth0/auth0-angular';
+import { environment as env } from '../environments/environment';
 
 //Components
 import { AppComponent } from './app.component';
@@ -41,6 +42,7 @@ import { CitationService } from './services/citation.service';
 import { FormatTimeSpan } from './components/citations/view-citations/formatTimespan';
 import { DriverLicenseDialogComponent } from './components/driver/driver-license-dialog/driver-license-dialog.component';
 import { InputErrorStateMatcher } from './error-state-matching';
+import { ProfileComponent } from './components/profile/profile.component';
 
 @NgModule({
   declarations: [
@@ -55,12 +57,11 @@ import { InputErrorStateMatcher } from './error-state-matching';
     EditDriverComponent,
     FormatTimeSpan,
     DriverLicenseDialogComponent,
+    ProfileComponent,
   ],
   imports: [
     AuthModule.forRoot({
-      domain: auth0.auth.domain,
-      clientId: auth0.auth.clientId,
-      redirectUri: window.location.origin,
+      ...env.auth,
     }),
     BrowserModule,
     AppRoutingModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
 import { MatCardModule } from '@angular/material/card'
 import { MatTabsModule } from '@angular/material/tabs';
+import { MatStepperModule } from '@angular/material/stepper';
 
 
 //Auth0
@@ -89,7 +90,8 @@ import { ViewCitationSummaryComponent } from './components/citations/view-citati
     MatButtonModule,
     MatIconModule,
     MatCardModule,
-    MatTabsModule
+    MatTabsModule,
+    MatStepperModule
   ],
   providers: [
     {provide: MatDialogRef, useValue: {}}, CitationService, 

--- a/src/app/components/citations/create-citation/create-citation.component.css
+++ b/src/app/components/citations/create-citation/create-citation.component.css
@@ -16,9 +16,9 @@ mat-form-field {
 }
 
 .mat-card {
-    width: 70%;
+    width: 50%;
     margin: 0 auto;
-    padding: 0;
+    padding: 0 0 25px 0;
 }
 
 .mat-card-content {

--- a/src/app/components/citations/create-citation/create-citation.component.css
+++ b/src/app/components/citations/create-citation/create-citation.component.css
@@ -41,4 +41,3 @@ tr {
     display: flex; 
     justify-content: center;
 }
-

--- a/src/app/components/citations/create-citation/create-citation.component.html
+++ b/src/app/components/citations/create-citation/create-citation.component.html
@@ -1,150 +1,316 @@
-<div class="main-container p-4" *ngIf="citation && citationViolations && citationWithViolations">
-    <form>
-        <mat-card tabindex="0" class="example-card">
-            <mat-card-header>
-                <mat-card-title>
-                    <h2>Citation</h2>
-                </mat-card-title>
-            </mat-card-header>
+<mat-stepper>
+    <mat-step [stepControl]="driverFormGroup">
+        <button  mat-raised-button color="primary" (click)="autoFillForm()">Dev Button - Autofill Form</button>
+        <form [formGroup]="driverFormGroup">
+            <ng-template matStepLabel="">Fill out driver's information</ng-template>
+            <mat-card tabindex="0" class="example-card">
+                <mat-card-header>
+                    <mat-card-title>
+                        <h2>Driver Information</h2>
+                    </mat-card-title>
+                </mat-card-header>
+                
+                <mat-card-content>
+                    <mat-form-field hintLabel="">
+                        <mat-label>License Number</mat-label>
+                        <input matInput [(ngModel)]="driver.license_no" #input formControlName="license_no" placeholder="Enter License Number" autocomplete="off" 
+                        oninput="this.value = this.value.toUpperCase()" maxlength="8"/>
+                        <mat-hint align="end"> {{ input.value.length || 0 }}/8 </mat-hint>
+                        <mat-error *ngIf="driverFormGroup.controls.license_no.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>License Class</mat-label>
+                        <mat-select [(ngModel)]="driver.license_class" placeholder="Select" formControlName="license_class">
+                            <mat-option value="C">C</mat-option>
+                            <mat-option value="A">A</mat-option>
+                            <mat-option value="B">B</mat-option>
+                        </mat-select>
+                        <mat-error *ngIf="driverFormGroup.controls.license_class.hasError('required')"><strong>Required</strong>
+                        </mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Name</mat-label>
+                        <input matInput [(ngModel)]="driver.driver_name" required formControlName="name" placeholder="Enter name" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.name.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Date of Birth</mat-label>
+                        <input matInput [(ngModel)]="driver.date_birth" formControlName="date_birth" placeholder="Enter DOB" type="date" autocomplete="off" />
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label> Hair Color </mat-label>
+                        <input matInput required [(ngModel)]="driver.hair" formControlName="hair" placeholder="Enter hair color" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.hair.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Eye Color</mat-label>
+                        <input matInput [(ngModel)]="driver.eyes" formControlName="eyes" placeholder="Enter eye color" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.eyes.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Height</mat-label>
+                        <span matSuffix>ft</span>
+                        <input matInput [(ngModel)]="driver.height" formControlName="height" placeholder="Enter height" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.height.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Weight</mat-label>
+                        <span matSuffix>lb</span>
+                        <input matInput [(ngModel)]="driver.weight" formControlName="weight" placeholder="Enter weight" maxlength="3" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.weight.hasError('required')"><strong>Required</strong></mat-error>
+                        <mat-error *ngIf="driverFormGroup.controls.weight.hasError('pattern')">
+                            Error: Only digits allowed
+                        </mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Race</mat-label>
+                        <input matInput [(ngModel)]="driver.race" formControlName="race" placeholder="Enter race" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.race.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Address</mat-label>
+                        <input matInput [(ngModel)]="driver.address" formControlName="address" placeholder="Enter address" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.address.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>City</mat-label>
+                        <input matInput [(ngModel)]="driver.city" formControlName="city" placeholder="Enter city" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.city.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>State</mat-label>
+                        <mat-select [(ngModel)]="driver.state" placeholder="Select" formControlName="state">
+                            <mat-option value="CA">CA</mat-option>
+                        </mat-select>
+                        <mat-error *ngIf="driverFormGroup.controls.state.hasError('required')"><strong>Required</strong></mat-error>
+                    </mat-form-field>
+            
+                    <mat-form-field>
+                        <mat-label>Zip</mat-label>
+                        <input matInput [(ngModel)]="driver.zip" formControlName="zip" placeholder="Enter zip code" maxlength="5" autocomplete="off" />
+                        <mat-error *ngIf="driverFormGroup.controls.zip.hasError('required')"><strong>Required</strong>
+                        </mat-error>
+                        <mat-error *ngIf="driverFormGroup.controls.zip.hasError('pattern')">
+                            Error: Only digits allowed
+                        </mat-error>
+                    </mat-form-field>
+    
+                    <div>
+                        <label>Sex</label>
+                        <mat-radio-group [(ngModel)]="driver.sex" formControlName="sex" aria-label="Select an option">
+                            <mat-radio-button value="M">M</mat-radio-button>
+                            <mat-radio-button value="F">F</mat-radio-button>
+                        </mat-radio-group>
+                        <mat-error *ngIf="driverFormGroup.controls.sex.hasError('required')"><strong>Required</strong></mat-error>
+                    </div>
+                </mat-card-content>
 
-            <mat-card-content>
-                <div>
-                    <mat-radio-group [(ngModel)]="citation.type" name="Type">
-                        <mat-radio-button value="Misdemeanor">Misdemeanor</mat-radio-button>
-                        <mat-radio-button value="Traffic">Traffic</mat-radio-button>
-                        <mat-radio-button value="Non-Traffic">Non-Traffic</mat-radio-button>
-                    </mat-radio-group>
-                    <br><br>
-                </div>
-
-                <mat-form-field>
-                    <mat-label>Date</mat-label>
-                    <input matInput required [(ngModel)]="citation.date" type="date" name="Date" />
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label>Time</mat-label>
-                    <input matInput required [ngModel]="(citation.time)" (ngModelChange)="citation.time = $event"
-                        type="time" name="Time" />
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label for="desc">Description</mat-label>
-                    <input matInput required [(ngModel)]="citation.desc" type="text" name="desc"
-                        placeholder="Description" />
-
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label for="violation_loc">Location</mat-label>
-                    <input matInput required [(ngModel)]="citation.violation_loc" type="text" name="violation_loc"
-                        placeholder="Location" />
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label for="vin">Vehicle License Number or VIN</mat-label>
-                    <input matInput required [(ngModel)]="citation.vin" type="text" name="vin"
-                        placeholder="Veh. Lic. No. or VIN" />
-                </mat-form-field>
-
-                <br>
-
-                <mat-form-field appearance="fill">
-                    <mat-label>State</mat-label>
-                    <mat-select [(ngModel)]="citation.vin_state" name="vin_state">
-                        <mat-option *ngFor="let state of states" [value]="state">{{state}}</mat-option>
-                    </mat-select>
-                </mat-form-field>
-
-                <form [formGroup]="productForm">
-                    <ng-container formArrayName="violations"
-                        *ngFor="let quantity of violations().controls; let i=index">
-                        <br><span class="text-center">Violation {{ i+1 }}</span><br>
-                        <div class="table-container">
-                            <tbody>
-                                <tr [formGroupName]="i">
-                                    <td class="mt-1 mb-3">
-                                        <button (click)="removeViolation(i)" class="btn btn-danger">Remove</button>
-                                    </td>
-                                </tr>
-                                <tr [formGroupName]="i">
-                                    <td>
-                                        <mat-form-field>
-                                            <mat-label>Group</mat-label>
-                                            <input matInput required [(ngModel)]="citationViolations[i].group"
-                                                type="text" formControlName="group" placeholder="Group">
-                                        </mat-form-field>
-                                    </td>
-                                    <td>
-                                        <mat-form-field>
-                                            <mat-label>Code</mat-label>
-                                            <input matInput required [(ngModel)]="citationViolations[i].code"
-                                                type="text" formControlName="code" placeholder="Code">
-                                        </mat-form-field>
-                                    </td>
-                                </tr>
-                                <tr [formGroupName]="i">
-                                    <td>
-                                        <mat-form-field>
-                                            <mat-label>Degree</mat-label>
-                                            <input matInput required [(ngModel)]="citationViolations[i].degree"
-                                                type="text" formControlName="degree" placeholder="Degree">
-                                        </mat-form-field>
-
-                                    </td>
-                                    <td>
-                                        <mat-form-field>
-                                            <mat-label>Description</mat-label>
-                                            <input matInput required [(ngModel)]="citationViolations[i].desc"
-                                                type="text" formControlName="desc" placeholder="Desc">
-                                        </mat-form-field>
-                                    </td>
-                                </tr>
-                            </tbody>
-
-                        </div>
-
-                    </ng-container>
-                    <br><button mat-raised-button color="primary" (click)="addViolation()">Add
-                        Violation</button><br><br>
-                </form>
-
-                <mat-form-field>
-                    <!-- Can probably prepopulate this from the officer's account information -->
-                    <mat-label for="officer_name">Arresting Officer Name</mat-label>
-                    <input matInput required [(ngModel)]="citation.officer_name" type="text" name="officer_name"
-                        placeholder="Name" />
-                </mat-form-field>
-
-                <mat-form-field>
-                    <!-- Can probably prepopulate this from the officer's account information -->
-                    <mat-label for="officer_badge">Badge No.</mat-label>
-                    <input matInput required [(ngModel)]="citation.officer_badge" type="text" name="officer_badge"
-                        placeholder="Badge #" />
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label>Signed Date</mat-label>
-                    <input matInput required [(ngModel)]="citation.sign_date" class="form-control" type="date"
-                        name="sign_date" />
-                </mat-form-field>
-
-                <div class="form-group">
-                    <label for="owner_fault">Owner's Fault?</label><br>
-
-                    <mat-radio-group [(ngModel)]="citation.owner_fault" name="owner_fault">
-                        <mat-radio-button [value]="true">Yes</mat-radio-button>
-                        <mat-radio-button [value]="false">No</mat-radio-button>
-                    </mat-radio-group>
-                </div>
-            </mat-card-content>
-
-            <mat-card-actions class="p-4">
-                <button mat-raised-button color="primary"
-                    (click)="createCitationWithViolations(citation, citationViolations, citationWithViolations)"
-                    *ngIf="!citation.citation_id" type="submit">Submit</button>
-            </mat-card-actions>
+                <mat-card-actions>
+                    <button mat-button matStepperPrevious>Back</button>
+                    <button mat-button matStepperNext>Next</button>
+                </mat-card-actions>
         </mat-card>
     </form>
+    </mat-step>
 
-</div>
+    <mat-step [stepControl]="citationFormGroup">
+        <form [formGroup]="citationFormGroup">
+            <ng-template matStepLabel>Fill out traffic citation</ng-template>
+            <div class="main-container p-4" *ngIf="citation && citationViolations && citationWithViolations">
+                <mat-card tabindex="0" class="example-card">
+                    <mat-card-header>
+                        <mat-card-title>
+                            <h2>Citation</h2>
+                        </mat-card-title>
+                    </mat-card-header>
+        
+                    <mat-card-content>
+                        <div>
+                            <mat-radio-group formControlName="type" [(ngModel)]="citation.type">
+                                <mat-radio-button value="Misdemeanor">Misdemeanor</mat-radio-button>
+                                <mat-radio-button value="Traffic">Traffic</mat-radio-button>
+                                <mat-radio-button value="Non-Traffic">Non-Traffic</mat-radio-button>
+                            </mat-radio-group>
+                            <br><br>
+                        </div>
+        
+                        <mat-form-field>
+                            <mat-label>Date</mat-label>
+                            <input matInput required formControlName="date" [(ngModel)]="citation.date" type="date"/>
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label>Time</mat-label>
+                            <input matInput required formControlName="time" [ngModel]="(citation.time)" (ngModelChange)="citation.time = $event"
+                                type="time" name="Time" />
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label for="desc">Description</mat-label>
+                            <input matInput required formControlName="desc" [(ngModel)]="citation.desc" type="text" name="desc"
+                                placeholder="Description" />
+        
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label for="violation_loc">Location</mat-label>
+                            <input matInput required formControlName="violation_loc" [(ngModel)]="citation.violation_loc" type="text" name="violation_loc"
+                                placeholder="Location" />
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label for="vin">Vehicle License Number or VIN</mat-label>
+                            <input matInput required formControlName="vin" [(ngModel)]="citation.vin" type="text" name="vin"
+                                placeholder="Veh. Lic. No. or VIN" />
+                        </mat-form-field>
+        
+                        <br>
+        
+                        <mat-form-field appearance="fill">
+                            <mat-label>State</mat-label>
+                            <mat-select formControlName="vin_state" [(ngModel)]="citation.vin_state" name="vin_state">
+                                <mat-option *ngFor="let state of states" [value]="state">{{state}}</mat-option>
+                            </mat-select>
+                        </mat-form-field>
+        
+                        <form [formGroup]="citationFormGroup">
+                            <ng-container formArrayName="violations"
+                                *ngFor="let quantity of violations().controls; let i=index">
+                                <br><span class="text-center">Violation {{ i+1 }}</span><br>
+                                <div class="table-container">
+                                    <tbody>
+                                        <tr [formGroupName]="i">
+                                            <td class="mt-1 mb-3">
+                                                <button (click)="removeViolation(i)" class="btn btn-danger">Remove</button>
+                                            </td>
+                                        </tr>
+                                        <tr [formGroupName]="i">
+                                            <td>
+                                                <mat-form-field>
+                                                    <mat-label>Group</mat-label>
+                                                    <input matInput required [(ngModel)]="citationViolations[i].group"
+                                                        type="text" formControlName="group" placeholder="Group">
+                                                </mat-form-field>
+                                            </td>
+                                            <td>
+                                                <mat-form-field>
+                                                    <mat-label>Code</mat-label>
+                                                    <input matInput required [(ngModel)]="citationViolations[i].code"
+                                                        type="text" formControlName="code" placeholder="Code">
+                                                </mat-form-field>
+                                            </td>
+                                        </tr>
+                                        <tr [formGroupName]="i">
+                                            <td>
+                                                <mat-form-field>
+                                                    <mat-label>Degree</mat-label>
+                                                    <input matInput required [(ngModel)]="citationViolations[i].degree"
+                                                        type="text" formControlName="degree" placeholder="Degree">
+                                                </mat-form-field>
+        
+                                            </td>
+                                            <td>
+                                                <mat-form-field>
+                                                    <mat-label>Description</mat-label>
+                                                    <input matInput required [(ngModel)]="citationViolations[i].desc"
+                                                        type="text" formControlName="desc" placeholder="Desc">
+                                                </mat-form-field>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+        
+                                </div>
+        
+                            </ng-container>
+                            <br><button mat-raised-button color="primary" (click)="addViolation()">Add
+                                Violation</button><br><br>
+                        </form>
+        
+                        <div class="form-group">
+                            <label>Owner's Fault?</label><br>
+                            <mat-radio-group formControlName="owner_fault" [(ngModel)]="citation.owner_fault">
+                                <mat-radio-button [value]="true">Yes</mat-radio-button>
+                                <mat-radio-button [value]="false">No</mat-radio-button>
+                            </mat-radio-group>
+                        </div>
+                    </mat-card-content>
+        
+                    <mat-card-actions class="p-4">
+                        <button mat-button matStepperPrevious>Back</button>
+                        <button mat-button matStepperNext>Next</button>
+                    </mat-card-actions>
+                </mat-card>
+            </div>
+        </form>
+    </mat-step>
+    
+    <mat-step>
+        <ng-template matStepLabel="">Officer Information</ng-template>
+        <form [formGroup]="officerFormGroup">
+            <div class="main-container p-4" *ngIf="citation">
+                <mat-card tabindex="0" class="example-card">
+                    <mat-card-header>
+                        <mat-card-title>
+                            <h2>Officer Information</h2>
+                        </mat-card-title>
+                    </mat-card-header>
+        
+                    <mat-card-content>
+                        <mat-form-field>
+                            <mat-label>Arresting Officer Name</mat-label>
+                            <input matInput required formControlName="officer_name" [(ngModel)]="citation.officer_name" type="text" placeholder="Name" />
+                        </mat-form-field>
+            
+                        <mat-form-field>
+                            <mat-label>Badge No.</mat-label>
+                            <input matInput required formControlName="officer_badge" [(ngModel)]="citation.officer_badge" type="text"
+                                placeholder="Badge #" />
+                        </mat-form-field>
+            
+                        <mat-form-field>
+                            <mat-label>Signed Date</mat-label>
+                            <input matInput required formControlName="sign_date" [(ngModel)]="citation.sign_date" class="form-control" type="date"/>
+                        </mat-form-field>
+                    </mat-card-content>
+        
+                    <mat-card-actions class="p-4">
+                        <button mat-button matStepperPrevious>Back</button>
+                        <button mat-button matStepperNext>Next</button>
+                    </mat-card-actions>
+                </mat-card>
+            </div>
+        </form>
+    </mat-step>
+
+    <mat-step *ngIf="citation">
+        <ng-template matStepLabel>Done</ng-template>
+        <div class="main-container p-4">
+            <mat-card>
+                <mat-card-header>
+                    <mat-card-title>
+                        <h2>Submit Citation</h2>
+                    </mat-card-title>
+                </mat-card-header>
+
+                <mat-card-actions>
+                    <button mat-button matStepperPrevious>Back</button>
+                    <button mat-raised-button color="primary"
+                                    (click)="onFormSubmit()"
+                                    *ngIf="!citation.citation_id" type="submit">Submit</button>
+                    <button mat-button>Reset Forms</button>
+                </mat-card-actions>
+            </mat-card>
+        </div>
+    </mat-step>
+</mat-stepper>

--- a/src/app/components/citations/create-citation/create-citation.component.html
+++ b/src/app/components/citations/create-citation/create-citation.component.html
@@ -13,7 +13,7 @@
                 <mat-card-content>
                     <mat-form-field hintLabel="">
                         <mat-label>License Number</mat-label>
-                        <input matInput [(ngModel)]="driver.license_no" #input formControlName="license_no" placeholder="Enter License Number" autocomplete="off" 
+                        <input matInput (ngModelChange)="findDriverByLicense($event)" [(ngModel)]="driver.license_no" #input formControlName="license_no" placeholder="Enter License Number" autocomplete="off" 
                         oninput="this.value = this.value.toUpperCase()" maxlength="8"/>
                         <mat-hint align="end"> {{ input.value.length || 0 }}/8 </mat-hint>
                         <mat-error *ngIf="driverFormGroup.controls.license_no.hasError('required')"><strong>Required</strong></mat-error>
@@ -255,7 +255,7 @@
         </form>
     </mat-step>
     
-    <mat-step>
+    <mat-step [stepControl]="officerFormGroup">
         <ng-template matStepLabel="">Officer Information</ng-template>
         <form [formGroup]="officerFormGroup">
             <div class="main-container p-4" *ngIf="citation">

--- a/src/app/components/citations/create-citation/create-citation.component.html
+++ b/src/app/components/citations/create-citation/create-citation.component.html
@@ -246,7 +246,7 @@
                         </div>
                     </mat-card-content>
         
-                    <mat-card-actions class="p-4">
+                    <mat-card-actions>
                         <button mat-button matStepperPrevious>Back</button>
                         <button mat-button matStepperNext>Next</button>
                     </mat-card-actions>
@@ -284,7 +284,7 @@
                         </mat-form-field>
                     </mat-card-content>
         
-                    <mat-card-actions class="p-4">
+                    <mat-card-actions>
                         <button mat-button matStepperPrevious>Back</button>
                         <button mat-button matStepperNext>Next</button>
                     </mat-card-actions>
@@ -295,21 +295,34 @@
 
     <mat-step *ngIf="citation">
         <ng-template matStepLabel>Done</ng-template>
-        <div class="main-container p-4">
+        <div class="main-container">
             <mat-card>
+                <mat-card-actions>
+                    
+                </mat-card-actions>
+
                 <mat-card-header>
                     <mat-card-title>
                         <h2>Submit Citation</h2>
                     </mat-card-title>
                 </mat-card-header>
 
-                <mat-card-actions>
-                    <button mat-button matStepperPrevious>Back</button>
-                    <button mat-raised-button color="primary"
+                <mat-card-content>
+                    <!-- <button mat-button matStepperPrevious>Back</button> -->
+                    <div class="mb-3">
+                        <button mat-raised-button color="primary"
                                     (click)="onFormSubmit()"
-                                    *ngIf="!citation.citation_id" type="submit">Submit</button>
-                    <button mat-button>Reset Forms</button>
-                </mat-card-actions>
+                                    *ngIf="!citation.citation_id && !citationCreated" type="submit">Submit</button>
+                    
+                        <button *ngIf="citationCreated" routerLink="/create-citation" routerLinkActive="active" mat-raised-button color="primary">Create Another</button>
+
+                    </div>
+                    
+                    
+                    <app-view-citation-summary>
+
+                    </app-view-citation-summary>
+                </mat-card-content>
             </mat-card>
         </div>
     </mat-step>

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -6,6 +6,7 @@ import { Citation } from 'src/app/models/citation';
 import { CitationWithViolations } from 'src/app/models/citation-with-violations';
 import { Violation } from 'src/app/models/violation';
 import { CitationService } from 'src/app/services/citation.service';
+import { SessionService } from 'src/app/services/session.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
 
 @Component({
@@ -85,7 +86,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
 
   productForm: FormGroup;
 
-  constructor(private citationService: CitationService, private fb: FormBuilder, private route: ActivatedRoute, private router: Router, private _snackBar: MatSnackBar) {
+  constructor(private citationService: CitationService, private fb: FormBuilder, private route: ActivatedRoute, private router: Router, private _snackBar: MatSnackBar, private session: SessionService) {
     super()
     this.productForm = this.fb.group({
       name:'',
@@ -114,7 +115,11 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
       this._snackBar.open("Successfully Created Traffic Citation", '', { duration: 2800 });
       console.log(result);
       
-      this.router.navigate(['/view-citation-summary', result?.citation_id]);
+      if (result) {
+        this.session.changeCitation(result);
+        this.session.changeViolations(citationViolations);
+        this.router.navigate(['/view-citation-summary', result?.citation_id]);
+      }
     });
   }
 

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormControl, FormGroup, FormArray, Validators } from '@ang
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
+import { toJSDate } from '@ng-bootstrap/ng-bootstrap/datepicker/ngb-calendar';
 import { Citation } from 'src/app/models/citation';
 import { CitationWithViolations } from 'src/app/models/citation-with-violations';
 import { Driver } from 'src/app/models/driver';
@@ -28,6 +29,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
   @Output() citationsWithViolationsCreated = new EventEmitter<CitationWithViolations[]>();
 
   existingDriverFound: boolean;
+  citationCreated: boolean;
 
   citations?: Citation[] = [];
   citationsWithViolations?: CitationWithViolations[] = [];
@@ -175,7 +177,10 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
   constructor(private citationService: CitationService, private driverService: DriverService, private route: ActivatedRoute, private router: Router, private _snackBar: MatSnackBar, private _formBuilder: FormBuilder, private dialog: MatDialog) {
     super()
     this.existingDriverFound = false;
+    this.citationCreated = false;
     this.driver = new Driver();
+
+    sessionStorage.clear();
   }
 
   ngOnInit(): void {
@@ -226,7 +231,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
           sessionStorage.setItem('citation', JSON.stringify(result));
           sessionStorage.setItem('violations', JSON.stringify(this.citationViolations));
   
-          this.router.navigate(['/view-citation-summary']);
+          this.citationCreated = true;
         }
       });
     }

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -1,12 +1,14 @@
+import { formatDate } from '@angular/common';
 import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup, FormArray } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, FormArray, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Citation } from 'src/app/models/citation';
 import { CitationWithViolations } from 'src/app/models/citation-with-violations';
+import { Driver } from 'src/app/models/driver';
 import { Violation } from 'src/app/models/violation';
 import { CitationService } from 'src/app/services/citation.service';
-import { SessionService } from 'src/app/services/session.service';
+import { DriverService } from 'src/app/services/driver.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
 
 @Component({
@@ -16,11 +18,20 @@ import { Unsubscriber } from 'src/app/services/unsubscriber';
 })
 
 export class CreateCitationComponent extends Unsubscriber implements OnInit {
+  @Input() driver: Driver;
   @Input() citation?: Citation; // citation model
   @Input() citationViolations?: Violation[] // array of violation models
   @Input() citationWithViolations?: CitationWithViolations; // model combining citation and violation(s) info
   @Output() citationsCreated = new EventEmitter<Citation[]>();
   @Output() citationsWithViolationsCreated = new EventEmitter<CitationWithViolations[]>();
+
+  existingDriverFound: boolean;
+
+  citations?: Citation[] = [];
+  citationsWithViolations?: CitationWithViolations[] = [];
+  
+  date = new FormControl(new Date());
+  serializedDate = new FormControl(new Date().toISOString()); 
 
   // array of all US states used for state drop-down menu
   states: string[] = [
@@ -76,61 +87,131 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
     'Wyoming',
   ];
 
-  driverId?: number;
+  // productForm = this._formBuilder.group({
+  //   name:'',
+  //   violations: this._formBuilder.array([]),
+  // });
 
-  citations: Citation[] = [];
-  citationsWithViolations: CitationWithViolations[] = [];
-  
-  date = new FormControl(new Date());
-  serializedDate = new FormControl(new Date().toISOString()); 
+  // Default age of driver is set to 18 years
+  defaultDate = formatDate(
+    new Date().setFullYear(new Date().getFullYear() - 18),
+    'yyyy-MM-dd',
+    'en-US'
+  );
 
-  productForm: FormGroup;
+  // FormsGroups to use for stepper
+  driverFormGroup = this._formBuilder.group({
+    name: ['', Validators.required, Validators.name],
+    date_birth: [this.defaultDate],
+    sex: ['F', Validators.required],
+    hair: ['', Validators.required],
+    eyes: ['', Validators.required],
+    height: ['', Validators.required],
+    weight: [<number | undefined>0, [
+      Validators.required,
+      Validators.pattern('^[0-9]*$')
+    ]],
+    race: ['', Validators.required],
+    address: ['', Validators.required],
+    city: ['', Validators.required],
+    state: ['', Validators.required],
+    zip: [<number | undefined>0, [
+      Validators.required,
+      Validators.pattern('^[0-9]*$')
+    ]],
+    license_no: ['', [
+      Validators.required,
+      Validators.pattern('^[A-Z]+[0-9]*$'),
+      Validators.maxLength(8),
+      Validators.minLength(8)
+    ]],
+    license_class: ['C', Validators.required]
 
-  constructor(private citationService: CitationService, private fb: FormBuilder, private route: ActivatedRoute, private router: Router, private _snackBar: MatSnackBar, private session: SessionService) {
+  });
+
+  currentDate = formatDate(new Date(), 'yyyy-MM-dd','en-US');
+
+  citationFormGroup = this._formBuilder.group({
+    type: ['', Validators.required],
+    date: [this.currentDate],
+    time: ['', Validators.required],
+    owner_fault: [true],
+    desc: [''],
+    violation_loc: ['', Validators.required],
+    vin: ['', Validators.required],
+    vin_state: [''],
+    violations: this._formBuilder.array([]),
+  });
+
+  officerFormGroup = this._formBuilder.group({
+    officer_name: [''],
+    officer_badge: [''],
+    sign_date: ['']
+  });
+
+  constructor(private citationService: CitationService, private driverService: DriverService, private fb: FormBuilder, private route: ActivatedRoute, private router: Router, private _snackBar: MatSnackBar, private _formBuilder: FormBuilder) {
     super()
-    this.productForm = this.fb.group({
-      name:'',
-      violations: this.fb.array([]),
-    }); 
+    this.existingDriverFound = false;
+    this.driver = new Driver();
   }
 
   ngOnInit(): void {
-    // Get driverId from previously created driver
-    this.route.params.subscribe(params => {
-      this.driverId = params['id'];
-    });
-    
     this.citation = new Citation();
-    this.citation.driver_id = this.driverId;
-
     this.citationViolations = [];
     this.citationWithViolations = new CitationWithViolations();
   }
 
-  // new create citation method that includes violations
-  createCitationWithViolations(citation: Citation, citationViolations: Violation[], citationWithViolations: CitationWithViolations) {
-    citationWithViolations.citation = citation;
-    citationWithViolations.violations = citationViolations;
-    this.addNewSubscription = this.citationService.createCitationWithViolations(citationWithViolations).subscribe(result => {
-      this._snackBar.open("Successfully Created Traffic Citation", '', { duration: 2800 });
-      console.log(result);
-      
-      if (result) {
-        sessionStorage.setItem('citation', JSON.stringify(result));
-        sessionStorage.setItem('violations', JSON.stringify(citationViolations));
+  onFormSubmit(): void {
+    this.saveCitationWithViolations();
+    this.saveDriver();
+  }
 
-        this.router.navigate(['/view-citation-summary']);
-      }
-    });
+  saveDriver() {
+    if (!this.existingDriverFound) {
+      this.addNewSubscription = this.driverService
+        .createDriver(this.driver)
+        .subscribe((result) => {
+          if (result) {
+            sessionStorage.setItem('driver', JSON.stringify(result));
+          }
+        });
+    } else {
+      this.addNewSubscription = this.driverService
+        .updateDriver(this.driver)
+        .subscribe((result) => {
+          if (result) {
+            sessionStorage.setItem('driver', JSON.stringify(result));
+          }
+        });
+    }
+  }
+
+  saveCitationWithViolations() {
+    if (this.citationWithViolations) {
+      this.citationWithViolations.citation = this.citation;
+      this.citationWithViolations.violations = this.citationViolations;
+
+      this.addNewSubscription = this.citationService.createCitationWithViolations(this.citationWithViolations).subscribe(result => {
+        this._snackBar.open("Successfully Created Traffic Citation", '', { duration: 2800 });
+        console.log(result);
+        
+        if (result) {
+          sessionStorage.setItem('citation', JSON.stringify(result));
+          sessionStorage.setItem('violations', JSON.stringify(this.citationViolations));
+  
+          this.router.navigate(['/view-citation-summary']);
+        }
+      });
+    }
   }
 
   violations() : FormArray {
-    return this.productForm.get("violations") as FormArray;
+    return this.citationFormGroup.get("violations") as FormArray;
   }
 
   // creates an empty violation
   newViolation() : FormGroup {
-    return this.fb.group({
+    return this._formBuilder.group({
       group:'',
       code:'',
       degree:'',
@@ -148,5 +229,22 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
   removeViolation(i: number) {
     this.violations().removeAt(i);
     this.citationViolations?.splice(i, 1);
+  }
+
+  autoFillForm(): void {
+    this.driver.driver_name = 'Otter';
+    this.driver.date_birth = this.defaultDate;
+    this.driver.sex = 'F';
+    this.driver.hair = 'Black';
+    this.driver.eyes = 'Green';
+    this.driver.height = '3\'00"';
+    this.driver.weight = 90;
+    this.driver.race = 'N/A';
+    this.driver.address = '100 ST.';
+    this.driver.city = 'Seaside';
+    this.driver.state = 'CA';
+    this.driver.zip = 99999;
+    this.driver.license_no = 'D1234567';
+    this.driver.license_class = 'C';
   }
 }

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -195,6 +195,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
         .createDriver(this.driver)
         .subscribe((result) => {
           if (result) {
+            this.driver = result;
             sessionStorage.setItem('driver', JSON.stringify(result));
           }
         });
@@ -203,6 +204,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
         .updateDriver(this.driver)
         .subscribe((result) => {
           if (result) {
+            this.driver = result;
             sessionStorage.setItem('driver', JSON.stringify(result));
           }
         });
@@ -220,6 +222,7 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
         console.log(result);
         
         if (result) {
+          this.citation = result;
           sessionStorage.setItem('citation', JSON.stringify(result));
           sessionStorage.setItem('violations', JSON.stringify(this.citationViolations));
   

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -110,10 +110,11 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
   createCitationWithViolations(citation: Citation, citationViolations: Violation[], citationWithViolations: CitationWithViolations) {
     citationWithViolations.citation = citation;
     citationWithViolations.violations = citationViolations;
-    this.addNewSubscription = this.citationService.createCitationWithViolations(citationWithViolations).subscribe(citationsWithViolations => {
-      this.citationsWithViolationsCreated.emit(citationsWithViolations);
+    this.addNewSubscription = this.citationService.createCitationWithViolations(citationWithViolations).subscribe(result => {
       this._snackBar.open("Successfully Created Traffic Citation", '', { duration: 2800 });
-      this.router.navigate(['/view-citations']);
+      console.log(result);
+      
+      this.router.navigate(['/view-citation-summary', result?.citation_id]);
     });
   }
 

--- a/src/app/components/citations/create-citation/create-citation.component.ts
+++ b/src/app/components/citations/create-citation/create-citation.component.ts
@@ -116,9 +116,10 @@ export class CreateCitationComponent extends Unsubscriber implements OnInit {
       console.log(result);
       
       if (result) {
-        this.session.changeCitation(result);
-        this.session.changeViolations(citationViolations);
-        this.router.navigate(['/view-citation-summary', result?.citation_id]);
+        sessionStorage.setItem('citation', JSON.stringify(result));
+        sessionStorage.setItem('violations', JSON.stringify(citationViolations));
+
+        this.router.navigate(['/view-citation-summary']);
       }
     });
   }

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
@@ -1,8 +1,8 @@
 .summary-container {
-  width: 50%;
+  width: 70%;
   margin: 0 auto;
   margin-top: 10px;
-  max-width: 800px;
+  max-width: 900px;
 }
 
 .mat-radio-button ~ .mat-radio-button {

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
@@ -1,0 +1,8 @@
+
+
+.summary-container {
+  width: 50%;
+  margin: 0 auto;
+  margin-top: 10px;
+  max-width: 550px;
+}

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.css
@@ -1,8 +1,45 @@
-
-
 .summary-container {
   width: 50%;
   margin: 0 auto;
   margin-top: 10px;
-  max-width: 550px;
+  max-width: 800px;
+}
+
+.mat-radio-button ~ .mat-radio-button {
+  margin-left: 16px;
+}
+
+mat-form-field {
+  margin-right: 12px;
+}
+
+.mat-card-header {
+  display: flex;
+  justify-content: center;
+  padding: 20px 0 0 0;
+  background-color: #2D4373;
+  color: white;
+  margin-bottom: 25px;
+}
+
+.mat-card {
+  width: 90%;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.mat-card-content {
+  margin: 0 auto;
+  text-align: center;
+  padding: 5px;
+}
+
+.mat-card-actions {
+  display: flex;
+  justify-content: center;
+}
+
+tr {
+  display: flex;
+  justify-content: center;
 }

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
@@ -1,0 +1,72 @@
+<div [class.mat-elevation-z5]="true" class="summary-container">
+    <mat-tab-group dynamicHeight mat-align-tabs="start" animationDuration="500ms" [selectedIndex]="0">
+
+        <mat-tab>
+            <!-- Label -->
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">description</mat-icon>
+                Citation
+            </ng-template>
+            Type:
+            {{ citation?.type }}<br>
+            <span *ngIf="violations && violations.length > 0">Violation Group:{{ violations[0].group}}</span>
+            <!-- Content -->
+    
+        </mat-tab>
+    
+        <mat-tab>
+            <!-- Label -->
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">person</mat-icon>
+                Driver
+            </ng-template>
+    
+            <!-- Content -->
+    
+        </mat-tab>
+    
+        <mat-tab>
+            <!-- Label -->
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">local_police</mat-icon>
+                Officer
+            </ng-template>
+    
+            <!-- Content -->
+    
+        </mat-tab>
+        
+      </mat-tab-group>
+
+
+</div>
+
+<!-- <mat-card>
+    <mat-tab-group dynamicHeight mat-align-tabs="center" animationDuration="2000ms">
+
+        <mat-tab>
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
+                Citation
+            </ng-template>
+        
+        </mat-tab>
+    
+        <mat-tab>
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
+                Driver
+            </ng-template>
+        
+        </mat-tab>
+    
+        <mat-tab>
+            <ng-template mat-tab-label>
+                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
+                Officer
+            </ng-template>
+        
+        </mat-tab>
+        
+      </mat-tab-group>
+</mat-card> -->

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
@@ -1,16 +1,116 @@
 <div [class.mat-elevation-z5]="true" class="summary-container">
-    <mat-tab-group dynamicHeight mat-align-tabs="start" animationDuration="500ms" [selectedIndex]="0">
+    <h1 class="text-center p-2">Citation Created</h1>
+    <button mat-raised-button color="primary">Create Another</button>
+    <button mat-raised-button color="accent">View Citations</button>
+</div>
 
+<div [class.mat-elevation-z5]="true" class="summary-container">
+    <mat-tab-group dynamicHeight mat-align-tabs="start" animationDuration="500ms" [selectedIndex]="0">
         <mat-tab>
             <!-- Label -->
             <ng-template mat-tab-label>
                 <mat-icon class="example-tab-icon">description</mat-icon>
                 Citation
             </ng-template>
-            Type:
-            {{ citation?.type }}<br>
-            <span *ngIf="violations && violations.length > 0">Violation Group:{{ violations[0].group}}</span>
-            <!-- Content -->
+
+            <div>
+                <mat-card tabindex="0" class="example-card">
+                    <mat-card-header>
+                        <mat-card-title>
+                            <h2>Citation</h2>
+                        </mat-card-title>
+                    </mat-card-header>
+        
+                    <mat-card-content>
+                        <div>
+                            <mat-label>Type</mat-label>
+                            <input matInput type="text" readonly [value]="citation?.type">
+                        </div>
+        
+                        <mat-form-field>
+                            <mat-label>Date</mat-label>
+                            <input matInput type="date" readonly [value]="citation?.date"/>
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label>Time</mat-label>
+                            <input matInput type="time" readonly [value]="(citation?.time)"/>
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label>Description</mat-label>
+                            <textarea matInput rows="5" type="text" readonly [value]="citation?.desc"></textarea>
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label>Location</mat-label>
+                            <input matInput type="text" readonly [value]="citation?.violation_loc"/>
+                        </mat-form-field>
+        
+                        <mat-form-field>
+                            <mat-label for="vin">Vehicle License Number or VIN</mat-label>
+                            <input matInput type="text" readonly [value]="citation?.vin"/>
+                        </mat-form-field>
+        
+                        <br>
+        
+                        <mat-form-field appearance="fill">
+                            <mat-label>State</mat-label>
+                            <input matInput type="text" readonly [value]="citation?.vin_state">
+                        </mat-form-field>
+        
+                        <ng-container formArrayName="violations"
+                            *ngFor="let quantity of violations; let i=index">
+                            <br><span class="text-center">Violation {{ i+1 }}</span><br>
+                            <div class="table-container">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <mat-form-field *ngIf="violations">
+                                                <mat-label>Group</mat-label>
+                                                <input matInput type="text" readonly [value]="violations[i].group">
+                                            </mat-form-field>
+                                        </td>
+                                        <td>
+                                            <mat-form-field *ngIf="violations">
+                                                <mat-label>Code</mat-label>
+                                                <input matInput type="text" readonly [value]="violations[i].code">
+                                            </mat-form-field>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <mat-form-field *ngIf="violations">
+                                                <mat-label>Degree</mat-label>
+                                                <input matInput type="text" readonly [value]="violations[i].degree">
+                                            </mat-form-field>
+                                        </td>
+                                        <td>
+                                            <mat-form-field *ngIf="violations">
+                                                <mat-label>Description</mat-label>
+                                                <input matInput type="text" readonly [value]="violations[i].desc">
+                                            </mat-form-field>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </div>
+                        </ng-container>                        
+ 
+                        <mat-form-field>
+                            <mat-label>Signed Date</mat-label>
+                            <input matInput type="date" readonly [value]="citation?.sign_date"/>
+                        </mat-form-field>
+        
+                        <div class="form-group">
+                            <label for="owner_fault">Owner's Fault?</label><br>
+                            <mat-radio-group [value]="citation?.owner_fault" name="owner_fault">
+                                <mat-radio-button [value]="true">Yes</mat-radio-button>
+                                <mat-radio-button [value]="false">No</mat-radio-button>
+                            </mat-radio-group>
+                        </div>
+                    </mat-card-content>
+                </mat-card>
+            </div>
     
         </mat-tab>
     
@@ -33,7 +133,19 @@
             </ng-template>
     
             <!-- Content -->
+            <form>
+                <mat-form-field>
+                    <!-- Can probably prepopulate this from the officer's account information -->
+                    <mat-label>Arresting Officer Name</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.officer_name"/>
+                </mat-form-field>
     
+                <mat-form-field>
+                    <!-- Can probably prepopulate this from the officer's account information -->
+                    <mat-label>Badge No.</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.officer_badge"/>
+                </mat-form-field>
+            </form>
         </mat-tab>
         
       </mat-tab-group>

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
@@ -1,9 +1,5 @@
-<div [class.mat-elevation-z5]="true" class="summary-container text-center p-2">
-    <button routerLink="/create-citation" routerLinkActive="active" mat-raised-button color="primary">Create Another</button>
-</div>
-
 <div [class.mat-elevation-z5]="true" class="summary-container">
-    <mat-tab-group dynamicHeight mat-align-tabs="start" animationDuration="500ms" [selectedIndex]="0">
+    <mat-tab-group mat-align-tabs="start" animationDuration="0ms" [selectedIndex]="0">
         <mat-tab>
             <!-- Label -->
             <ng-template mat-tab-label>
@@ -12,96 +8,92 @@
             </ng-template>
 
             <div>
-                <mat-card class="mt-1">
-                    <mat-card-content>
-                        <mat-form-field>
-                            <mat-label>Type</mat-label>
-                            <input matInput type="text" readonly [value]="citation?.type">
-                        </mat-form-field>
-        
-                        <mat-form-field>
-                            <mat-label>Date</mat-label>
-                            <input matInput type="date" readonly [value]="citation?.date"/>
-                        </mat-form-field>
-        
-                        <mat-form-field>
-                            <mat-label>Time</mat-label>
-                            <input matInput type="time" readonly [value]="(citation?.time)"/>
-                        </mat-form-field>
-        
-                        <mat-form-field>
-                            <mat-label>Description</mat-label>
-                            <textarea matInput rows="5" type="text" readonly [value]="citation?.desc"></textarea>
-                        </mat-form-field>
-        
-                        <mat-form-field>
-                            <mat-label>Location</mat-label>
-                            <input matInput type="text" readonly [value]="citation?.violation_loc"/>
-                        </mat-form-field>
-        
-                        <mat-form-field>
-                            <mat-label for="vin">Vehicle License Number or VIN</mat-label>
-                            <input matInput type="text" readonly [value]="citation?.vin"/>
-                        </mat-form-field>
-        
-                        <br>
-        
-                        <mat-form-field appearance="fill">
-                            <mat-label>State</mat-label>
-                            <input matInput type="text" readonly [value]="citation?.vin_state">
-                        </mat-form-field>
-        
-                        <ng-container
-                            *ngFor="let quantity of violations; let i=index">
-                            <br><span class="text-center">Violation {{ i+1 }}</span><br>
-                            <div class="table-container">
-                                <tbody>
-                                    <tr>
-                                        <td>
-                                            <mat-form-field *ngIf="violations">
-                                                <mat-label>Group</mat-label>
-                                                <input matInput type="text" readonly [value]="violations[i].group">
-                                            </mat-form-field>
-                                        </td>
-                                        <td>
-                                            <mat-form-field *ngIf="violations">
-                                                <mat-label>Code</mat-label>
-                                                <input matInput type="text" readonly [value]="violations[i].code">
-                                            </mat-form-field>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <mat-form-field *ngIf="violations">
-                                                <mat-label>Degree</mat-label>
-                                                <input matInput type="text" readonly [value]="violations[i].degree">
-                                            </mat-form-field>
-                                        </td>
-                                        <td>
-                                            <mat-form-field *ngIf="violations">
-                                                <mat-label>Description</mat-label>
-                                                <input matInput type="text" readonly [value]="violations[i].desc">
-                                            </mat-form-field>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </div>
-                        </ng-container>                        
- 
-                        <mat-form-field>
-                            <mat-label>Signed Date</mat-label>
-                            <input matInput type="date" readonly [value]="citation?.sign_date"/>
-                        </mat-form-field>
-        
-                        <div class="form-group">
-                            <label for="owner_fault">Owner's Fault?</label><br>
-                            <mat-radio-group [value]="citation?.owner_fault" name="owner_fault">
-                                <mat-radio-button [value]="true">Yes</mat-radio-button>
-                                <mat-radio-button [value]="false">No</mat-radio-button>
-                            </mat-radio-group>
-                        </div>
-                    </mat-card-content>
-                </mat-card>
+                <mat-form-field>
+                    <mat-label>Type</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.type">
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Date</mat-label>
+                    <input matInput type="date" readonly [value]="citation?.date"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Time</mat-label>
+                    <input matInput type="time" readonly [value]="(citation?.time)"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Description</mat-label>
+                    <textarea matInput rows="5" type="text" readonly [value]="citation?.desc"></textarea>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Location</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.violation_loc"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label for="vin">Vehicle License Number or VIN</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.vin"/>
+                </mat-form-field>
+
+                <br>
+
+                <mat-form-field appearance="fill">
+                    <mat-label>State</mat-label>
+                    <input matInput type="text" readonly [value]="citation?.vin_state">
+                </mat-form-field>
+
+                <ng-container
+                    *ngFor="let quantity of violations; let i=index">
+                    <br><span class="text-center">Violation {{ i+1 }}</span><br>
+                    <div class="table-container">
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <mat-form-field *ngIf="violations">
+                                        <mat-label>Group</mat-label>
+                                        <input matInput type="text" readonly [value]="violations[i].group">
+                                    </mat-form-field>
+                                </td>
+                                <td>
+                                    <mat-form-field *ngIf="violations">
+                                        <mat-label>Code</mat-label>
+                                        <input matInput type="text" readonly [value]="violations[i].code">
+                                    </mat-form-field>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <mat-form-field *ngIf="violations">
+                                        <mat-label>Degree</mat-label>
+                                        <input matInput type="text" readonly [value]="violations[i].degree">
+                                    </mat-form-field>
+                                </td>
+                                <td>
+                                    <mat-form-field *ngIf="violations">
+                                        <mat-label>Description</mat-label>
+                                        <input matInput type="text" readonly [value]="violations[i].desc">
+                                    </mat-form-field>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </div>
+                </ng-container>                        
+
+                <mat-form-field>
+                    <mat-label>Signed Date</mat-label>
+                    <input matInput type="date" readonly [value]="citation?.sign_date"/>
+                </mat-form-field>
+
+                <div class="form-group">
+                    <label for="owner_fault">Owner's Fault?</label><br>
+                    <mat-radio-group [value]="citation?.owner_fault" name="owner_fault">
+                        <mat-radio-button [value]="true">Yes</mat-radio-button>
+                        <mat-radio-button [value]="false">No</mat-radio-button>
+                    </mat-radio-group>
+                </div>
             </div>
     
         </mat-tab>
@@ -112,8 +104,70 @@
                 <mat-icon class="example-tab-icon">person</mat-icon>
                 Driver
             </ng-template>
-    
-            <!-- Content -->
+
+            <div>
+                <mat-form-field>
+                    <mat-label>Name</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.driver_name"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Date of Birth</mat-label>
+                    <input matInput type="date" readonly [value]="driver?.date_birth"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Sex</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.sex"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Hair Color</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.hair"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Eye Color</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.eyes"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Height</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.height"/>
+                </mat-form-field>
+
+                <br>
+
+                <mat-form-field>
+                    <mat-label>Address</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.address"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>City</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.city"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>State</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.state"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>Zip</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.zip"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>License Number</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.license_no"/>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>License Class</mat-label>
+                    <input matInput type="text" readonly [value]="driver?.license_class"/>
+                </mat-form-field>
+            </div>
     
         </mat-tab>
     

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.html
@@ -1,7 +1,5 @@
-<div [class.mat-elevation-z5]="true" class="summary-container">
-    <h1 class="text-center p-2">Citation Created</h1>
-    <button mat-raised-button color="primary">Create Another</button>
-    <button mat-raised-button color="accent">View Citations</button>
+<div [class.mat-elevation-z5]="true" class="summary-container text-center p-2">
+    <button routerLink="/create-citation" routerLinkActive="active" mat-raised-button color="primary">Create Another</button>
 </div>
 
 <div [class.mat-elevation-z5]="true" class="summary-container">
@@ -14,18 +12,12 @@
             </ng-template>
 
             <div>
-                <mat-card tabindex="0" class="example-card">
-                    <mat-card-header>
-                        <mat-card-title>
-                            <h2>Citation</h2>
-                        </mat-card-title>
-                    </mat-card-header>
-        
+                <mat-card class="mt-1">
                     <mat-card-content>
-                        <div>
+                        <mat-form-field>
                             <mat-label>Type</mat-label>
                             <input matInput type="text" readonly [value]="citation?.type">
-                        </div>
+                        </mat-form-field>
         
                         <mat-form-field>
                             <mat-label>Date</mat-label>
@@ -59,7 +51,7 @@
                             <input matInput type="text" readonly [value]="citation?.vin_state">
                         </mat-form-field>
         
-                        <ng-container formArrayName="violations"
+                        <ng-container
                             *ngFor="let quantity of violations; let i=index">
                             <br><span class="text-center">Violation {{ i+1 }}</span><br>
                             <div class="table-container">
@@ -126,13 +118,10 @@
         </mat-tab>
     
         <mat-tab>
-            <!-- Label -->
             <ng-template mat-tab-label>
                 <mat-icon class="example-tab-icon">local_police</mat-icon>
                 Officer
             </ng-template>
-    
-            <!-- Content -->
             <form>
                 <mat-form-field>
                     <!-- Can probably prepopulate this from the officer's account information -->
@@ -147,38 +136,5 @@
                 </mat-form-field>
             </form>
         </mat-tab>
-        
       </mat-tab-group>
-
-
 </div>
-
-<!-- <mat-card>
-    <mat-tab-group dynamicHeight mat-align-tabs="center" animationDuration="2000ms">
-
-        <mat-tab>
-            <ng-template mat-tab-label>
-                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
-                Citation
-            </ng-template>
-        
-        </mat-tab>
-    
-        <mat-tab>
-            <ng-template mat-tab-label>
-                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
-                Driver
-            </ng-template>
-        
-        </mat-tab>
-    
-        <mat-tab>
-            <ng-template mat-tab-label>
-                <mat-icon class="example-tab-icon">thumb_up</mat-icon>
-                Officer
-            </ng-template>
-        
-        </mat-tab>
-        
-      </mat-tab-group>
-</mat-card> -->

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
@@ -1,13 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { Citation } from 'src/app/models/citation';
 import { Driver } from 'src/app/models/driver';
 import { Violation } from 'src/app/models/violation';
-import { CitationService } from 'src/app/services/citation.service';
-import { DriverService } from 'src/app/services/driver.service';
-import { SessionService } from 'src/app/services/session.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
-import { ViolationService } from 'src/app/services/violation.service';
 
 @Component({
   selector: 'app-view-citation-summary',
@@ -18,32 +13,17 @@ export class ViewCitationSummaryComponent
   extends Unsubscriber
   implements OnInit, OnDestroy
 {
-  citationId: number = 0;
   citation?: Citation;
   violations?: Violation[];
   driver?: Driver;
 
-  constructor(
-    private session: SessionService
-  ) {
+  // TODO: Use local storage instead of session to store data in browser cache
+
+  constructor() {
     super();
   }
 
   ngOnInit(): void {
-    this.addNewSubscription = this.session.currentCitation.subscribe(
-      (citation) => (this.citation = citation)
-    );
-
-    this.addNewSubscription = this.session.currentViolations.subscribe(
-      (violations) => (this.violations = violations)
-    );
-
-    this.addNewSubscription = this.session.currentDriver.subscribe(
-      (driver) => (this.driver = driver)
-    );
-
-    // Retrieve citation, violations, and driver from session storage
-    // Used if page refreshes
     this.retrieveSessionValues();
   }
 
@@ -51,8 +31,7 @@ export class ViewCitationSummaryComponent
     // Parse JSON string from session storage as Citation
     if (sessionStorage.getItem('citation')) {
       this.citation = JSON.parse(
-        sessionStorage.getItem('citation') || '{}'
-      ) as Citation;
+        sessionStorage.getItem('citation') || '{}') as Citation;
     }
 
     if (sessionStorage.getItem('violations')) {

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
@@ -11,7 +11,7 @@ import { Unsubscriber } from 'src/app/services/unsubscriber';
 })
 export class ViewCitationSummaryComponent
   extends Unsubscriber
-  implements OnInit, OnDestroy
+  implements OnInit
 {
   citation?: Citation;
   violations?: Violation[];

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
@@ -24,8 +24,6 @@ export class ViewCitationSummaryComponent
   driver?: Driver;
 
   constructor(
-    private violationService: ViolationService,
-    private driverService: DriverService,
     private session: SessionService
   ) {
     super();
@@ -33,24 +31,7 @@ export class ViewCitationSummaryComponent
 
   ngOnInit(): void {
     this.addNewSubscription = this.session.currentCitation.subscribe(
-      (citation) => {
-        this.citation = citation;
-        // Retrieve all violations belonging to Citation
-        // this.addNewSubscription = this.violationService
-        //   .getViolationsByCitationId(citation?.citation_id!)
-        //   .subscribe((result) => {
-        //     this.violations = result;
-            
-        //   });
-
-        // // Retrieve citation driver
-        // this.addNewSubscription = this.driverService
-        //   .getDriverById(citation?.driver_id!)
-        //   .subscribe((result) => {
-        //     this.driver = result;
-            
-        //   });
-      }
+      (citation) => (this.citation = citation)
     );
 
     this.addNewSubscription = this.session.currentViolations.subscribe(

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Citation } from 'src/app/models/citation';
+import { Driver } from 'src/app/models/driver';
+import { Violation } from 'src/app/models/violation';
+import { CitationService } from 'src/app/services/citation.service';
+import { DriverService } from 'src/app/services/driver.service';
+import { Unsubscriber } from 'src/app/services/unsubscriber';
+import { ViolationService } from 'src/app/services/violation.service';
+
+@Component({
+  selector: 'app-view-citation-summary',
+  templateUrl: './view-citation-summary.component.html',
+  styleUrls: ['./view-citation-summary.component.css']
+})
+export class ViewCitationSummaryComponent extends Unsubscriber implements OnInit {
+  citationId: number = 0;
+  citation?: Citation;
+  violations?: Violation[];
+  driver?: Driver;
+
+  constructor(private route: ActivatedRoute, private citationService: CitationService, private violationService: ViolationService, private driverService: DriverService) {
+    super();
+  }
+
+  ngOnInit(): void {
+    // TODO: Pass object instead of id as route param
+
+    // Get citation from route params (from when citation was created)
+    this.route.params.subscribe(params => {
+      this.citationId = params['id'];
+      
+      // Retrieve Citation
+      this.addNewSubscription = this.citationService.getCitationById(this.citationId).subscribe(result => {
+        this.citation = result;
+      });
+
+      // Retrieve all violations belonging to Citation
+      this.addNewSubscription = this.violationService.getViolationsByCitationId(this.citationId).subscribe(result => {
+        this.violations = result;
+      })
+
+      this.addNewSubscription = this.driverService.getDriverById(this.citation?.driver_id!).subscribe(result => {
+        this.driver = result;
+      })
+    });
+
+    
+  }
+
+}

--- a/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
+++ b/src/app/components/citations/view-citation-summary/view-citation-summary.component.ts
@@ -1,51 +1,85 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Citation } from 'src/app/models/citation';
 import { Driver } from 'src/app/models/driver';
 import { Violation } from 'src/app/models/violation';
 import { CitationService } from 'src/app/services/citation.service';
 import { DriverService } from 'src/app/services/driver.service';
+import { SessionService } from 'src/app/services/session.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
 import { ViolationService } from 'src/app/services/violation.service';
 
 @Component({
   selector: 'app-view-citation-summary',
   templateUrl: './view-citation-summary.component.html',
-  styleUrls: ['./view-citation-summary.component.css']
+  styleUrls: ['./view-citation-summary.component.css'],
 })
-export class ViewCitationSummaryComponent extends Unsubscriber implements OnInit {
+export class ViewCitationSummaryComponent
+  extends Unsubscriber
+  implements OnInit, OnDestroy
+{
   citationId: number = 0;
   citation?: Citation;
   violations?: Violation[];
   driver?: Driver;
 
-  constructor(private route: ActivatedRoute, private citationService: CitationService, private violationService: ViolationService, private driverService: DriverService) {
+  constructor(
+    private violationService: ViolationService,
+    private driverService: DriverService,
+    private session: SessionService
+  ) {
     super();
   }
 
   ngOnInit(): void {
-    // TODO: Pass object instead of id as route param
+    this.addNewSubscription = this.session.currentCitation.subscribe(
+      (citation) => {
+        this.citation = citation;
+        // Retrieve all violations belonging to Citation
+        // this.addNewSubscription = this.violationService
+        //   .getViolationsByCitationId(citation?.citation_id!)
+        //   .subscribe((result) => {
+        //     this.violations = result;
+            
+        //   });
 
-    // Get citation from route params (from when citation was created)
-    this.route.params.subscribe(params => {
-      this.citationId = params['id'];
-      
-      // Retrieve Citation
-      this.addNewSubscription = this.citationService.getCitationById(this.citationId).subscribe(result => {
-        this.citation = result;
-      });
+        // // Retrieve citation driver
+        // this.addNewSubscription = this.driverService
+        //   .getDriverById(citation?.driver_id!)
+        //   .subscribe((result) => {
+        //     this.driver = result;
+            
+        //   });
+      }
+    );
 
-      // Retrieve all violations belonging to Citation
-      this.addNewSubscription = this.violationService.getViolationsByCitationId(this.citationId).subscribe(result => {
-        this.violations = result;
-      })
+    this.addNewSubscription = this.session.currentViolations.subscribe(
+      (violations) => (this.violations = violations)
+    );
 
-      this.addNewSubscription = this.driverService.getDriverById(this.citation?.driver_id!).subscribe(result => {
-        this.driver = result;
-      })
-    });
+    this.addNewSubscription = this.session.currentDriver.subscribe(
+      (driver) => (this.driver = driver)
+    );
 
-    
+    // Retrieve citation, violations, and driver from session storage
+    // Used if page refreshes
+    this.retrieveSessionValues();
   }
 
+  retrieveSessionValues() {
+    // Parse JSON string from session storage as Citation
+    if (sessionStorage.getItem('citation')) {
+      this.citation = JSON.parse(
+        sessionStorage.getItem('citation') || '{}'
+      ) as Citation;
+    }
+
+    if (sessionStorage.getItem('violations')) {
+      this.violations = JSON.parse(sessionStorage.getItem('violations') || '{}') as Violation[];
+    }
+
+    if (sessionStorage.getItem('driver')) {
+      this.driver = JSON.parse(sessionStorage.getItem('driver') || '{}') as Driver;
+    }
+  }
 }

--- a/src/app/components/citations/view-citations/view-citations.component.ts
+++ b/src/app/components/citations/view-citations/view-citations.component.ts
@@ -44,7 +44,7 @@ export class ViewCitationsComponent extends Unsubscriber implements AfterViewIni
 
   constructor(private citationService: CitationService, private dialog: MatDialog) {
     super()
-    this.paginator = new MatPaginator(new MatPaginatorIntl, ChangeDetectorRef.prototype)
+    this.paginator = new MatPaginator(new MatPaginatorIntl, ChangeDetectorRef.prototype);
   }
 
   ngOnInit(): void {
@@ -56,12 +56,14 @@ export class ViewCitationsComponent extends Unsubscriber implements AfterViewIni
   }
 
   loadCitationsPage() {
-    this.loadCitations(this.paginator.pageIndex, this.paginator.pageSize);
+    this.loadCitations(this.paginator.pageIndex + 1, this.paginator.pageSize);
   }
 
   // Retrieve citations from database. Display progress spinner until data is loaded
   loadCitations(pageNumber = 1, pageSize = 5) {
     this.loadingSubject.next(true);
+    console.log("Paginator page index " + this.paginator.pageIndex);
+    console.log("Function page index " + pageNumber);
 
     this.addNewSubscription = this.citationService
       .getCitationsPaginator(pageNumber, pageSize)

--- a/src/app/components/citations/view-citations/view-citations.component.ts
+++ b/src/app/components/citations/view-citations/view-citations.component.ts
@@ -62,8 +62,8 @@ export class ViewCitationsComponent extends Unsubscriber implements AfterViewIni
   // Retrieve citations from database. Display progress spinner until data is loaded
   loadCitations(pageNumber = 1, pageSize = 5) {
     this.loadingSubject.next(true);
-    console.log("Paginator page index " + this.paginator.pageIndex);
-    console.log("Function page index " + pageNumber);
+    // console.log("Paginator page index " + this.paginator.pageIndex);
+    // console.log("Function page index " + pageNumber);
 
     this.addNewSubscription = this.citationService
       .getCitationsPaginator(pageNumber, pageSize)

--- a/src/app/components/driver/create-driver/create-driver.component.ts
+++ b/src/app/components/driver/create-driver/create-driver.component.ts
@@ -164,7 +164,7 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
         .updateDriver(this.driver)
         .subscribe((result) => {
           if (result) {
-            this.session.changeDriver(result);
+            sessionStorage.setItem('driver', JSON.stringify(result));
             this.router.navigate(['/create-citation', result?.driver_id]);
           }
           

--- a/src/app/components/driver/create-driver/create-driver.component.ts
+++ b/src/app/components/driver/create-driver/create-driver.component.ts
@@ -9,6 +9,7 @@ import { duration } from 'moment';
 import { InputErrorStateMatcher } from 'src/app/error-state-matching';
 import { Driver } from 'src/app/models/driver';
 import { DriverService } from 'src/app/services/driver.service';
+import { SessionService } from 'src/app/services/session.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
 import { DriverLicenseDialogComponent } from '../driver-license-dialog/driver-license-dialog.component';
 
@@ -16,7 +17,7 @@ import { DriverLicenseDialogComponent } from '../driver-license-dialog/driver-li
   selector: 'app-create-driver',
   templateUrl: './create-driver.component.html',
   styleUrls: ['./create-driver.component.css'],
-  providers: []
+  providers: [],
 })
 export class CreateDriverComponent extends Unsubscriber implements OnInit {
   @Input() driver: Driver;
@@ -26,27 +27,48 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
   existingDriverFound: boolean;
 
   // Default age of driver is set to 18 years
-  defaultDate = formatDate(new Date().setFullYear(new Date().getFullYear() - 18), 'yyyy-MM-dd', 'en-US');
+  defaultDate = formatDate(
+    new Date().setFullYear(new Date().getFullYear() - 18),
+    'yyyy-MM-dd',
+    'en-US'
+  );
 
   driverForm = new FormGroup({
-    name: new FormControl('' [Validators.required, Validators.name]),
+    name: new FormControl(''[(Validators.required, Validators.name)]),
     date_birth: new FormControl(this.defaultDate),
     sex: new FormControl('F', [Validators.required]),
     hair: new FormControl('', [Validators.required]),
     eyes: new FormControl('', [Validators.required]),
     height: new FormControl('', [Validators.required]),
-    weight: new FormControl(<number|undefined>(0), [Validators.required, Validators.pattern('^[0-9]*$')]),
+    weight: new FormControl(<number | undefined>0, [
+      Validators.required,
+      Validators.pattern('^[0-9]*$'),
+    ]),
     race: new FormControl('', [Validators.required]),
     address: new FormControl('', [Validators.required]),
     city: new FormControl('', [Validators.required]),
-    state: new FormControl('',[Validators.required]),
-    zip: new FormControl(<number|undefined>(0), [Validators.required, Validators.pattern('^[0-9]*$')]),
-    license_no: new FormControl('', [Validators.required, Validators.pattern('^[A-Z]+[0-9]*$'), Validators.maxLength(8), Validators.minLength(8)]),
+    state: new FormControl('', [Validators.required]),
+    zip: new FormControl(<number | undefined>0, [
+      Validators.required,
+      Validators.pattern('^[0-9]*$'),
+    ]),
+    license_no: new FormControl('', [
+      Validators.required,
+      Validators.pattern('^[A-Z]+[0-9]*$'),
+      Validators.maxLength(8),
+      Validators.minLength(8),
+    ]),
     license_class: new FormControl('C', [Validators.required]),
-  })
+  });
 
-  constructor(private driverService: DriverService, private dialog: MatDialog, private router: Router, private _snackBar: MatSnackBar) {
-    super()
+  constructor(
+    private driverService: DriverService,
+    private dialog: MatDialog,
+    private router: Router,
+    private _snackBar: MatSnackBar,
+    private session: SessionService
+  ) {
+    super();
     this.createDriverNow = false;
     this.existingDriverFound = false;
     this.driver = new Driver();
@@ -62,14 +84,14 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
     this.driverForm.controls.sex.setValue('F');
     this.driverForm.controls.hair.setValue('Black');
     this.driverForm.controls.eyes.setValue('Green');
-    this.driverForm.controls.height.setValue("3'00\"");
+    this.driverForm.controls.height.setValue('3\'00"');
     this.driverForm.controls.weight.setValue(90);
-    this.driverForm.controls.race.setValue("N/A");
-    this.driverForm.controls.address.setValue("100 ST.");
-    this.driverForm.controls.city.setValue("Seaside");
-    this.driverForm.controls.state.setValue("CA");
+    this.driverForm.controls.race.setValue('N/A');
+    this.driverForm.controls.address.setValue('100 ST.');
+    this.driverForm.controls.city.setValue('Seaside');
+    this.driverForm.controls.state.setValue('CA');
     this.driverForm.controls.zip.setValue(99999);
-    this.driverForm.controls.license_no.setValue("D1234567");
+    this.driverForm.controls.license_no.setValue('D1234567');
     this.driverForm.controls.license_class.setValue('C');
   }
 
@@ -85,7 +107,7 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
   }
 
   // Use getter and setter because ngModel is deprecated with FormControlName as of Angular V6..
-  updateDriverValues(){
+  updateDriverValues() {
     this.driver.driver_name = this.driverForm.get('name')?.value;
     this.driver.date_birth = this.driverForm.get('date_birth')?.value as string;
     this.driver.sex = this.driverForm.get('sex')?.value as string;
@@ -99,7 +121,8 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
     this.driver.state = this.driverForm.get('state')?.value as string;
     this.driver.zip = this.driverForm.get('zip')?.value as number;
     this.driver.license_no = this.driverForm.get('license_no')?.value as string;
-    this.driver.license_class = this.driverForm.get('license_class')?.value as string;
+    this.driver.license_class = this.driverForm.get('license_class')
+      ?.value as string;
   }
 
   setDriverValues() {
@@ -118,55 +141,69 @@ export class CreateDriverComponent extends Unsubscriber implements OnInit {
         state: this.driver.state,
         zip: this.driver.zip,
         license_no: this.driver.license_no,
-        license_class: this.driver.license_class
+        license_class: this.driver.license_class,
       });
     }
   }
 
   createDriver() {
-
     if (!this.existingDriverFound) {
       this.updateDriverValues();
-      this.addNewSubscription = this.driverService.createDriver(this.driver).subscribe((result => {
-        // Pass driverID to create citation route
-        this.router.navigate(['/create-citation', result?.driver_id]);
-      }));
+      this.addNewSubscription = this.driverService
+        .createDriver(this.driver)
+        .subscribe((result) => {
+          // Pass driverID to create citation route
+          if (result) {
+            this.session.changeDriver(result);
+            this.router.navigate(['/create-citation', result?.driver_id]);
+          }
+        });
     } else {
       this.updateDriverValues();
-      this.addNewSubscription = this.driverService.updateDriver(this.driver).subscribe((result => {
-        this.router.navigate(['/create-citation', result?.driver_id]);
-      }));
+      this.addNewSubscription = this.driverService
+        .updateDriver(this.driver)
+        .subscribe((result) => {
+          if (result) {
+            this.session.changeDriver(result);
+            this.router.navigate(['/create-citation', result?.driver_id]);
+          }
+          
+        });
     }
-    
   }
 
   // If license number exists retrieves driver information and auto fills form
   // If no driver is found fills license number only
   openDialog() {
     const dialogConfig = new MatDialogConfig();
-    
+
     dialogConfig.autoFocus = true;
     dialogConfig.disableClose = true;
     dialogConfig.width = '335px';
     dialogConfig.height = 'auto';
 
     const dialogRef = this.dialog
-    .open(DriverLicenseDialogComponent, dialogConfig)
-    .afterClosed()
-    .subscribe(result => {
-      if (typeof(result) === 'string') {
-        this.driverForm.patchValue({weight: null, zip: null, license_no: result})
-        this.existingDriverFound = false;
-        this._snackBar.open("Driver not found. Enter Manually.", '', { duration: 3000 });
-      } else if (typeof(result) === 'object') {
-        this.driver = result;
-        this.setDriverValues();
-        this.existingDriverFound = true;
-        this._snackBar.open("Existing driver found!", '', { duration: 2800 });
-      }
-      this.createDriverNow = true; // Can now fill form
-    });
+      .open(DriverLicenseDialogComponent, dialogConfig)
+      .afterClosed()
+      .subscribe((result) => {
+        if (typeof result === 'string') {
+          this.driverForm.patchValue({
+            weight: null,
+            zip: null,
+            license_no: result,
+          });
+          this.existingDriverFound = false;
+          this._snackBar.open('Driver not found. Enter Manually.', '', {
+            duration: 3000,
+          });
+        } else if (typeof result === 'object') {
+          this.driver = result;
+          this.setDriverValues();
+          this.existingDriverFound = true;
+          this._snackBar.open('Existing driver found!', '', { duration: 2800 });
+        }
+        this.createDriverNow = true; // Can now fill form
+      });
     this.addNewSubscription = dialogRef;
   }
-
 }

--- a/src/app/components/driver/driver-license-dialog/driver-license-dialog.component.html
+++ b/src/app/components/driver/driver-license-dialog/driver-license-dialog.component.html
@@ -1,32 +1,10 @@
-<form [formGroup]="licenseForm" (ngSubmit)="onFormSubmit()">
+<form>
   <div mat-dialog-title>
-    <h2 class="title">Check for existing driver</h2>
-    <button class="close-btn" mat-icon-button mat-dialog-close aria-label="close dialog">
-      <mat-icon class="close-icon">close</mat-icon>
-    </button>
+    <h2 class="title">Existing driver found. Autofill Form?</h2>
   </div>
-
-  <div mat-dialog-content>
-    <mat-form-field class="mat-form" appearance="outline">
-      <mat-label>License Number</mat-label>
-      <input
-        #input
-        matInput
-        autocomplete="off"
-        oninput="this.value = this.value.toUpperCase()"
-        formControlName="license_no"
-        placeholder="Enter License Number"
-        [errorStateMatcher]="matcher"
-        maxlength="8"
-      />
-      <mat-hint align="end"> {{ input.value.length || 0 }}/8 </mat-hint>
-      <mat-error *ngIf="licenseForm.controls.license_no.hasError('pattern')"
-        >Must start with letter followed by seven numbers</mat-error>
-      <mat-error *ngIf="licenseForm.controls.license_no.hasError('required')">License Number Required</mat-error>
-    </mat-form-field>
-  </div>
-
+  
   <div mat-dialog-actions>
-    <button mat-raised-button color="primary">Submit</button>
+    <button mat-raised-button color="primary" (click)="onConfirm()">Yes</button>
+    <button mat-raised-button color="warn" (click)="onDismiss()">No</button>
   </div>
 </form>

--- a/src/app/components/driver/driver-license-dialog/driver-license-dialog.component.ts
+++ b/src/app/components/driver/driver-license-dialog/driver-license-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
+import { toJSDate } from '@ng-bootstrap/ng-bootstrap/datepicker/ngb-calendar';
 import { InputErrorStateMatcher } from 'src/app/error-state-matching';
 import { DriverService } from 'src/app/services/driver.service';
 import { Unsubscriber } from 'src/app/services/unsubscriber';
@@ -11,41 +12,14 @@ import { CreateDriverComponent } from '../create-driver/create-driver.component'
   templateUrl: './driver-license-dialog.component.html',
   styleUrls: ['./driver-license-dialog.component.css'],
 })
-export class DriverLicenseDialogComponent extends Unsubscriber implements OnInit {
-  matcher = new InputErrorStateMatcher();
+export class DriverLicenseDialogComponent {
+  constructor(private dialogRef: MatDialogRef<CreateDriverComponent>) { }
 
-  licenseForm = new FormGroup({
-    // California License numbers start with 1 Alpha + 7 numeric, TODO: Finish regex pattern
-    license_no: new FormControl('', [Validators.required, Validators.pattern('^[A-Z]+[0-9]*$')]),
-  })
-
-  constructor(
-    private driverService: DriverService,
-    private dialogRef: MatDialogRef<CreateDriverComponent>
-  ) {
-    super();
+  onConfirm() {
+    this.dialogRef.close(true);
   }
 
-  ngOnInit(): void {}
-
-  // On form submit get driver by their license number
-  // If no driver exists create a new one
-  onFormSubmit() {
-    this.getDriverByLicense();
-  }
-
-  // Get license number value from form
-  get licenseNumber(): any {
-    return this.licenseForm.get('license_no')?.value;
-  }
-
-  getDriverByLicense() {
-    this.addNewSubscription = this.driverService.getDriverByLicenseNo(this.licenseNumber).subscribe(result => {
-      if (result != undefined) {
-        this.dialogRef.close(result);
-      } else {
-        this.dialogRef.close(this.licenseNumber);
-      }
-    });
+  onDismiss() {
+    this.dialogRef.close(false);
   }
 }

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,4 +1,6 @@
  <body>
+  <button mat-raised-button *ngIf="(auth.isAuthenticated$ | async)" color="warn" (click)="logout()">Logout</button>
+
     <style>
         body {
           background-image: url('../assets/monterey-ca-court.3a03c085123fa5682f13.jpg');

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Component, Inject, OnInit } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
 
 @Component({
   selector: 'app-home',
@@ -7,10 +9,15 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HomeComponent implements OnInit {
 
-  constructor() { }
+  constructor(public auth: AuthService, @Inject(DOCUMENT) private doc: Document) { }
 
   ngOnInit(): void {
     window.scrollTo(0, 0)
+  }
+
+  // Move later, for testing login
+  logout(): void {
+    this.auth.logout({ returnTo: this.doc.location.origin });
   }
 
 }

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -1,1 +1,1 @@
-<button mat-raised-button color="primary" (click)="loginWithRedirect()">Login</button>
+<button mat-raised-button *ngIf="(auth.isAuthenticated$ | async) === false" color="primary" (click)="loginWithRedirect()">Login</button>

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { AuthService } from '@auth0/auth0-angular';
+import { DOCUMENT } from '@angular/common'
 
 @Component({
   selector: 'app-login',
@@ -7,7 +8,7 @@ import { AuthService } from '@auth0/auth0-angular';
 })
 export class LoginComponent implements OnInit {
 
-  constructor(public auth: AuthService) { }
+  constructor(public auth: AuthService, @Inject(DOCUMENT) private doc: Document) { }
 
   ngOnInit(): void {
   }

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,0 +1,4 @@
+<ul *ngIf="auth.user$ | async as user">
+    <li> {{ user.name }} </li>
+    <li> {{ user.email }} </li>
+</ul>

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-profile',
+  templateUrl: './profile.component.html',
+  styleUrls: ['./profile.component.css']
+})
+export class ProfileComponent implements OnInit {
+
+  constructor(public auth: AuthService) { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/services/citation.service.ts
+++ b/src/app/services/citation.service.ts
@@ -20,7 +20,11 @@ export class CitationService {
     return this.http.get<Citation[]>(`${environment.apiUrl}/${this.url}`).pipe(catchError(this.errorService.handleError));
   }
 
-  public getCitationsPaginator(pageNumber: number,pageSize: number) : Observable<any> {
+  public getCitationById(citation_id: number) : Observable<Citation | undefined> {
+    return this.http.get<Citation>(`${environment.apiUrl}/${this.url}/${citation_id}`).pipe(catchError(this.errorService.handleError));
+  }
+
+  public getCitationsPaginator(pageNumber: number, pageSize: number) : Observable<any> {
     return this.http.get<any>(`${environment.apiUrl}/${this.url}/${pageNumber}/${pageSize}`).pipe(catchError(this.errorService.handleError));
   }
 
@@ -29,8 +33,8 @@ export class CitationService {
   }
 
   // creates a citation with 1 or more violations
-  public createCitationWithViolations(citation: CitationWithViolations) : Observable<CitationWithViolations[] | undefined> {
-    return this.http.post<CitationWithViolations[]>(`${environment.apiUrl}/${this.newUrl}`, citation).pipe(catchError(this.errorService.handleError));
+  public createCitationWithViolations(citation: CitationWithViolations) : Observable<Citation | undefined> {
+    return this.http.post<Citation>(`${environment.apiUrl}/${this.newUrl}`, citation).pipe(catchError(this.errorService.handleError));
   }
 
   public updateCitation(citation: Citation) : Observable<Citation[] | undefined> {

--- a/src/app/services/error-service.ts
+++ b/src/app/services/error-service.ts
@@ -19,6 +19,8 @@ export class ErrorHandleService {
     if (error.status === 404) {
       // Not found so return undefined
       return of(undefined);
+    } else if(error.status === 400) {
+      return of(undefined);
     } else if (error.error instanceof ErrorEvent) {
       // Frontend error
       errorMessage = error.error.message;

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, OnInit } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Citation } from '../models/citation';
+import { Driver } from '../models/driver';
+import { Violation } from '../models/violation';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SessionService implements OnInit {
+  private citation?: Citation;
+  private violations?: Violation[];
+  private driver?: Driver;
+
+  private citationSource = new BehaviorSubject(this.citation);
+  private violationsSource = new BehaviorSubject(this.violations);
+  private driverSource = new BehaviorSubject(this.driver);
+
+  currentCitation = this.citationSource.asObservable();
+  currentViolations = this.violationsSource.asObservable();
+  currentDriver = this.driverSource.asObservable();
+
+  constructor() {
+  }
+
+    ngOnInit(): void {
+    
+  }
+
+  // Change currently loaded citation
+  changeCitation(citation: Citation) {
+    this.citationSource.next(citation);
+    // Store in session too
+    sessionStorage.setItem('citation', JSON.stringify(citation));
+  }
+
+  changeViolations(violations: Violation[]) {
+    this.violationsSource.next(violations);
+    sessionStorage.setItem('violations', JSON.stringify(violations));
+  }
+
+  changeDriver(driver: Driver) {
+    this.driverSource.next(driver);
+    sessionStorage.setItem('driver', JSON.stringify(driver));
+  }
+}

--- a/src/app/services/violation.service.ts
+++ b/src/app/services/violation.service.ts
@@ -17,6 +17,10 @@ export class ViolationService {
         return this.http.get<Violation[]>(`${environment.apiUrl}/${this.url}`).pipe(catchError(this.errorService.handleError));
     }
 
+    public getViolationsByCitationId(citation_id: number) : Observable<Violation[] | undefined> {
+        return this.http.get<Violation[]>(`${environment.apiUrl}/${this.url}/${citation_id}`).pipe(catchError(this.errorService.handleError));
+    }
+
     public createViolation(violation: Violation) : Observable<Violation[] | undefined> {
         return this.http.post<Violation[]>(`${environment.apiUrl}/${this.url}`, violation).pipe(catchError(this.errorService.handleError));
     }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,15 @@
+const domain = require('auth_config.json').domain;
+const clientId = require('auth_config.json').clientId;
+const apiUrl = require('auth_config.json').apiUrl;
+
 export const environment = {
   production: true,
   apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
   //apiUrl: "https://localhost:7190/api"
+  auth: {
+    domain,
+    clientId,
+    apiUrl,
+    redirectUri: window.location.origin,
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,8 +7,8 @@ const apiUrl = require('auth_config.json').apiUrl;
 
 export const environment = {
   production: false,
-  apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
-  //apiUrl: "https://localhost:7190/api"
+  //apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
+  apiUrl: "https://localhost:7190/api",
   auth: {
     domain,
     clientId,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,9 +4,6 @@
 const domain = require('auth_config.json').domain;
 const clientId = require('auth_config.json').clientId;
 const apiUrl = require('auth_config.json').apiUrl;
-const refreshToken = require('auth_config.json').refreshToken;
-const cacheLocation = require('auth_config.json').cacheLocation;
-
 
 export const environment = {
   production: false,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,8 +7,8 @@ const apiUrl = require('auth_config.json').apiUrl;
 
 export const environment = {
   production: false,
-  //apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
-  apiUrl: "https://localhost:7190/api",
+  apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
+  //apiUrl: "https://localhost:7190/api",
   auth: {
     domain,
     clientId,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,11 +1,23 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
+const domain = require('auth_config.json').domain;
+const clientId = require('auth_config.json').clientId;
+const apiUrl = require('auth_config.json').apiUrl;
+const refreshToken = require('auth_config.json').refreshToken;
+const cacheLocation = require('auth_config.json').cacheLocation;
+
 
 export const environment = {
-  production: true,
+  production: false,
   apiUrl: "https://traffic-citation-backend.herokuapp.com/api",
   //apiUrl: "https://localhost:7190/api"
+  auth: {
+    domain,
+    clientId,
+    apiUrl,
+    redirectUri: window.location.origin,
+  },
 };
 
 /*


### PR DESCRIPTION
## Changes

### Summary Page
***Summary page doesn't display information yet. Need to modify sessionStorage.
The last step of creating a new citation now includes a summary of citation (using angular material tabs). It shows driver information, the traffic citation itself, and officer information. There is a button to create another citation (doesn't work yet) when current citation is submitted.

~~Summary page retrieves citation information from sessionStorage. If the page is refreshed data will be persistent. If the tab or browser is closed then sessionStorage is deleted.~~


### Update to finding existing driver
Instead of prompting user to enter drive license number inside of a dialog the form now automatically checks for an existing driver as you type a license number into the input field. If an existing driver is found a dialog opens asking if you want to autofill the form with the existing driver's information.

### Misc changes
- Implemented Angular material stepper for all forms (each form is a step with final step being form submission)
- Forms are now all handled through one component (create citation component) instead of multiple components.
- Added session service that can be used later.
- Fixed pagination bug where it wouldn't show correct page
- +Some other changes I'm forgetting.

### What to do next
Validate forms and don't allow submission of citation if fields are empty.
